### PR TITLE
Fix primitive C types: there is no int_t nor long_t

### DIFF
--- a/src/impact/recommended-use-c-types.md
+++ b/src/impact/recommended-use-c-types.md
@@ -7,7 +7,7 @@ As confusion frequently arises about the most appropriate types to use for
 integers, pointers, and pointer-related values, we make the following
 recommendations:
 
-* **`int_t`, `int32_t`, `long_t`, `int64_t`, ...**: These pure integer types
+* **`int`, `int32_t`, `long`, `int64_t`, ...**: These pure integer types
   should be used to hold integer values
   that will never be cast to a pointer type without first combining them with
   another pointer value &mdash; e.g., by using them as an array offset.


### PR DESCRIPTION
Those where listed as 'int' and 'long' in UCAM-CL-TR-947, but got changed to 'int_t' and 'long_t' with 2d693cce6fd7 ("First cut at conversion from LaTeX to mdbook for the CHERI C/C++ guide."). Switch this back to the primitive C types 'int' and 'long'.